### PR TITLE
Install influx client via system package

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Read more about InfluxDBv2 in the [official documentation](https://docs.influxda
 ## Installation
 `ansible-galaxy collection install tbauriedel.influxdb2`
 
+On rpm based Distributions you need the EPEL repository to be available.
+
 ## Roles
 
 * [Role: repos](roles/repos/README.md) - Install the official InfluxDb repositories

--- a/molecule/influxdb2/converge.yml
+++ b/molecule/influxdb2/converge.yml
@@ -24,3 +24,10 @@
   roles:
     - repos
     - influxdb2
+
+  pre_tasks:
+    - name: Activate EPEL on rpm based distros
+      package:
+        name: epel-release
+      when:
+        - ansible_os_family == "RedHat"

--- a/molecule/influxdb2/molecule.yml
+++ b/molecule/influxdb2/molecule.yml
@@ -14,7 +14,5 @@ platforms:
     pre_build_image: true
 provisioner:
   name: ansible
-  env:
-    ANSIBLE_VERBOSITY: 3
 verifier:
   name: ansible

--- a/molecule/influxdb2/prepare.yml
+++ b/molecule/influxdb2/prepare.yml
@@ -7,4 +7,4 @@
         name: "{{ item }}"
       loop:
         - requests
-        - influxdb_client
+

--- a/roles/influxdb2/tasks/install.yml
+++ b/roles/influxdb2/tasks/install.yml
@@ -3,7 +3,7 @@
   ansible.builtin.package:
     name:
       - python3
-      - python3-influxdb
+      - python3-influxdb-client
     state: present
 
 - name: Install InfluxDB

--- a/roles/influxdb2/tasks/install.yml
+++ b/roles/influxdb2/tasks/install.yml
@@ -3,12 +3,7 @@
   ansible.builtin.package:
     name:
       - python3
-      - python3-pip
-    state: present
-
-- name: Install influxb-client for python
-  ansible.builtin.pip:
-    name: influxdb-client
+      - python3-influxdb
     state: present
 
 - name: Install InfluxDB


### PR DESCRIPTION
All supported distributions should have a package providing the InfluxDB client available.

Instead of using `pip` we can simply install the package.