### PR TITLE
Allow to override package Python installation with pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Read more about InfluxDBv2 in the [official documentation](https://docs.influxda
 * [Module: influxdb2_organization](doc/modules/influxdb2_organization.py): Create, update and delete InfluxDBv2 organizations
 * [Module: influxdb2_bucket](doc/modules/influxdb2_bucket.md.py): Create, update and delete InfluxDBv2 buckets
 
+## Variables
+
+* `influxdb_force_pip`: Pip won't let you install Python modules if there is a package managed Python installation. Since the required modules are not available on all supported distributions you can override this behaviour by setting this variable to `true`. (Default: not set)
+
 ## Example
 
 ```

--- a/README.md
+++ b/README.md
@@ -18,10 +18,6 @@ Read more about InfluxDBv2 in the [official documentation](https://docs.influxda
 * [Module: influxdb2_organization](doc/modules/influxdb2_organization.py): Create, update and delete InfluxDBv2 organizations
 * [Module: influxdb2_bucket](doc/modules/influxdb2_bucket.md.py): Create, update and delete InfluxDBv2 buckets
 
-## Variables
-
-* `influxdb_force_pip`: Pip won't let you install Python modules if there is a package managed Python installation. Since the required modules are not available on all supported distributions you can override this behaviour by setting this variable to `true`. (Default: not set)
-
 ## Example
 
 ```

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,2 +1,2 @@
 ---
-requires_ansible: ">=2.9"
+requires_ansible: ">=2.17"

--- a/molecule/influxdb2/converge.yml
+++ b/molecule/influxdb2/converge.yml
@@ -7,7 +7,7 @@
       - name: org1
         desc: "This is a description"
         token: "{{ influxdb_influxdb2_admin_token }}"
-    influxdb_force_pip: true
+    influxdb_influxdb2_force_pip: true
 
     influxdb_influxdb2_buckets:
       - name: bucket-1

--- a/molecule/influxdb2/converge.yml
+++ b/molecule/influxdb2/converge.yml
@@ -7,6 +7,7 @@
       - name: org1
         desc: "This is a description"
         token: "{{ influxdb_influxdb2_admin_token }}"
+    influxdb_force_pip: true
 
     influxdb_influxdb2_buckets:
       - name: bucket-1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,4 @@
-ansible-core==2.16.3
+ansible-core==2.17.9
 ansible-lint
 molecule
 molecule-docker

--- a/roles/influxdb2/README.md
+++ b/roles/influxdb2/README.md
@@ -20,7 +20,7 @@ At the moment the configuration is very basic. Over time, this role will be expa
 * `influxdb_influxdb2_primary_bucket`: Primary bucket (default: 'default')
 * `influxdb_influxdb2_retention`: Retention for primary bucket (default: '0')
 * `influxdb_influxdb2_admin_token`: Admin API token created in the setup (default: 'Random123ChangeMe!')
-* `influxdb_influxdb2_force_pip`: Pip won't let you install Python modules if there is a package managed Python installation. Since the required modules are not available on all supported distributions you can override this behaviour by setting this variable to `true`. (Default: not set)
+* `influxdb_influxdb2_force_pip`: Pip won't let you install Python modules if there is a package managed Python installation. Since the required modules are not available on all supported distributions you can override this behaviour by setting this variable to `true`. (Default: `false`)
 
 **Organizations**
 * `influxdb_influxdb2_orgs`: List of organizations to manage

--- a/roles/influxdb2/README.md
+++ b/roles/influxdb2/README.md
@@ -20,6 +20,7 @@ At the moment the configuration is very basic. Over time, this role will be expa
 * `influxdb_influxdb2_primary_bucket`: Primary bucket (default: 'default')
 * `influxdb_influxdb2_retention`: Retention for primary bucket (default: '0')
 * `influxdb_influxdb2_admin_token`: Admin API token created in the setup (default: 'Random123ChangeMe!')
+* `influxdb_influxdb2_force_pip`: Pip won't let you install Python modules if there is a package managed Python installation. Since the required modules are not available on all supported distributions you can override this behaviour by setting this variable to `true`. (Default: not set)
 
 **Organizations**
 * `influxdb_influxdb2_orgs`: List of organizations to manage

--- a/roles/influxdb2/defaults/main.yml
+++ b/roles/influxdb2/defaults/main.yml
@@ -19,3 +19,5 @@ influxdb_influxdb2_retention: 0
 
 influxdb_influxdb2_buckets: []
 influxdb_influxdb2_orgs: []
+
+influxdb_force_influxdb2_pip: false

--- a/roles/influxdb2/defaults/main.yml
+++ b/roles/influxdb2/defaults/main.yml
@@ -20,4 +20,4 @@ influxdb_influxdb2_retention: 0
 influxdb_influxdb2_buckets: []
 influxdb_influxdb2_orgs: []
 
-influxdb_force_influxdb2_pip: false
+influxdb_influxdb2_force_pip: false

--- a/roles/influxdb2/tasks/install.yml
+++ b/roles/influxdb2/tasks/install.yml
@@ -8,7 +8,7 @@
 
 - name: Install influxdb-client via block for rescue
   when:
-    - not influxdb_force_influxdb2_pip | bool
+    - not influxdb_influxdb2_force_pip | bool
   block:
     - name: Install influxdb-client for python
       ansible.builtin.pip:

--- a/roles/influxdb2/tasks/install.yml
+++ b/roles/influxdb2/tasks/install.yml
@@ -6,10 +6,26 @@
       - python3-pip
     state: present
 
-- name: Install influxb-client for python
+- name: Install influxdb-client via block for rescue
+  when:
+    - not influxdb_force_pip | bool
+  block:
+    - name: Install influxdb-client for python
+      ansible.builtin.pip:
+        name: influxdb-client
+        state: present
+  rescue:
+    - name: Fail with error message
+      fail:
+        msg: NOTE You can force this installation. See README about variable influxdb_force_pip
+
+- name: Install influxb-client for python (forced)
   ansible.builtin.pip:
     name: influxdb-client
     state: present
+    break_system_packages: true
+  when:
+    - influxdb_force_pip | bool
 
 - name: Install InfluxDB
   ansible.builtin.package:

--- a/roles/influxdb2/tasks/install.yml
+++ b/roles/influxdb2/tasks/install.yml
@@ -8,7 +8,7 @@
 
 - name: Install influxdb-client via block for rescue
   when:
-    - not influxdb_force_pip | bool
+    - not influxdb_force_influxdb2_pip | bool
   block:
     - name: Install influxdb-client for python
       ansible.builtin.pip:
@@ -16,8 +16,8 @@
         state: present
   rescue:
     - name: Fail with error message
-      fail:
-        msg: NOTE You can force this installation. See README about variable influxdb_force_pip
+      ansible.builtin.fail:
+        msg: NOTE You can force this installation. See README about variable influxdb_influxdb2_force_pip
 
 - name: Install influxb-client for python (forced)
   ansible.builtin.pip:
@@ -25,7 +25,7 @@
     state: present
     break_system_packages: true
   when:
-    - influxdb_force_pip | bool
+    - influxdb_influxdb2_force_pip | bool
 
 - name: Install InfluxDB
   ansible.builtin.package:


### PR DESCRIPTION
Pip won't let you install modules when a package managed Python installation is present on the system. Since we need modules which are not available on all supported distributions, we might have to override this.

This pull request will introduce a variable to do exactly that.