### PR TITLE
Add module to manage access tokens

### DIFF
--- a/doc/modules/influxdb2_auth.md
+++ b/doc/modules/influxdb2_auth.md
@@ -1,0 +1,58 @@
+# Ansible module: influxdb2_auth
+
+This module creates, updates and deletes access tokens from your InfluxDB2.
+
+## Requirements
+
+As this module uses the InfluxDB2 API you will need to install the InfluxDB2 Python3 library.
+
+`pip3 install influxdb-client`
+
+## Module arguments
+* `name`: Name of token. Only used inside of the module to identify the token (saved in description)
+* `state`: State of the token ('present' or 'absent')
+* `desc`: Description (Only use in case you dont want to manage the token again after creation. Is used to identify it again)
+* `org`: Organization name
+* `token`: API token to manage the token
+* `verify_ssl`: Verify ssl certificates (Default: `true`)
+* `host`: InfluxDB Host to use in API call
+* `permissions`: **List** of permissions. An example can be found below.
+
+```yaml
+permissions:
+  - buckets: # resource
+      - action: read # action
+        bucket: my-bucket # bucket name (only needed for the bucket resource)
+  - dashboards:
+      - action: read
+  - variables:
+      - action: read
+      - action: write
+  - ...
+```
+
+Supported resources:  
+- buckets (requires 'action' and 'bucket' name), dashboards, variables, tasks, checks, notifications, orgs, authorizations, labels, secrets, views, documents
+
+Supported actions:  
+- read, write
+
+> Note!
+> If an existing token’s permissions differ from the desired state, the module deletes and recreates the token under the hood.
+> This causes the actual token string to change. Plan accordingly if you store tokens externally or pass them to applications.
+
+## Example usage
+
+```
+- name: Manage auth tokens
+  tbauriedel.influxdb2.influxdb2_auth:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    desc: "{{ item.desc | default(omit) }}"
+    org: "{{ item.org }}"
+    token: "{{ influxdb2_influxdb2_admin_token }}"
+    host: "{{ influxdb2_influxdb2_host }}"
+    verify_ssl: "{{ item.verify_ssl | default(true) }}"
+    permissions: "{{ item.permissions }}"
+  loop: "{{ influxdb2_influxdb2_tokens }}"
+```

--- a/doc/modules/influxdb2_bucket.md
+++ b/doc/modules/influxdb2_bucket.md
@@ -1,4 +1,4 @@
-# Ansible module: influxdb_bucket
+# Ansible module: influxdb2_bucket
 
 This module creates, updates and deletes buckets from your InfluxDB2.
 

--- a/molecule/influxdb2/converge.yml
+++ b/molecule/influxdb2/converge.yml
@@ -52,6 +52,24 @@
           everySeconds: '60000'
           shardGroupDurationSeconds: '7600'
 
+    influxdb2_influxdb2_tokens:
+      - name: token-1
+        state: present
+        org: org1
+        token: "{{ influxdb2_influxdb2_admin_token }}"
+        verify_ssl: false
+        permissions:
+          - buckets:
+              - action: read
+                bucket: bucket-1
+              - action: write
+                bucket: bucket-1
+          - dashboards:
+              - action: read
+          - variables:
+              - action: read
+              - action: write
+
   collections:
     - tbauriedel.influxdb2
 

--- a/plugins/module_utils/influxdb2_auth.py
+++ b/plugins/module_utils/influxdb2_auth.py
@@ -1,0 +1,217 @@
+# !/usr/bin/python3
+
+# Copyright (c) 2025, Tobias Bauriedel <tobias@bauriedel.de>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+from influxdb_client import Permission, PermissionResource, Authorization
+from ansible_collections.tbauriedel.influxdb2.plugins.module_utils.api import Api
+from ansible_collections.tbauriedel.influxdb2.plugins.module_utils.influxdb2_organization import OrgApi
+from ansible_collections.tbauriedel.influxdb2.plugins.module_utils.influxdb2_bucket import BucketApi
+
+
+class AuthApi():
+    SUPPORTED_RESOURCES = {
+        "buckets": {
+            "resolver": "bucket",
+            "type": "buckets"
+        },
+        "dashboards": {
+            "resolver": None,
+            "type": "dashboards"
+        },
+        "tasks": {
+            "resolver": None,
+            "type": "tasks"
+        },
+        "orgs": {
+            "resolver": None,
+            "type": "orgs"
+        },
+        "users": {
+            "resolver": None,
+            "type": "users"
+        },
+        "authorizations": {
+            "resolver": None,
+            "type": "authorizations"
+        },
+        "secrets": {
+            "resolver": None,
+            "type": "secrets"
+        },
+        "variables": {
+            "resolver": None,
+            "type": "variables"
+        },
+        "labels": {
+            "resolver": None,
+            "type": "labels"
+        },
+        "telegrafs": {
+            "resolver": None,
+            "type": "telegrafs"
+        },
+        "checks": {
+            "resolver": None,
+            "type": "checks"
+        },
+        "notificationsRules": {
+            "resolver": None,
+            "type": "notificationRules"
+        },
+        "notificationEndpoints": {
+            "resolver": None,
+            "type": "notificationEndpoints"
+        },
+        "scrapers": {
+            "resolver": None,
+            "type": "scrapers"
+        },
+        "remotes": {
+            "resolver": None,
+            "type": "remotes"
+        },
+        "replications": {
+            "resolver": None,
+            "type": "replications"
+        },
+        "flows": {
+            "resolver": None,
+            "type": "flows"
+        }
+    }
+
+    def __init__(self, host, token, name, org, state, desc=None, permissions=None, verify_ssl=True, result=None):
+        self.name = name
+        self.host = host
+        self.token = token
+        self.org = org
+        self.state = state
+        self.desc = desc
+        self.permissions = permissions or []
+        self.verify_ssl = verify_ssl
+        self.result = result or {"changed": False}
+
+        self.client = Api.new_client(host=host, token=token, verify_ssl=verify_ssl).authorizations_api()
+        self.org_api = OrgApi(host=host, token=token, verify_ssl=verify_ssl)
+        self.bucket_api = BucketApi(name="", state="", desc="", host=host, token=token, org=org, retention={}, verify_ssl=verify_ssl, result={})
+
+    def return_result(self):
+        return self.result
+
+    def handle(self):
+        if self.state == 'absent':
+            self.handle_absent()
+        elif self.state == 'present':
+            self.handle_present()
+        return
+
+    def handle_absent(self):
+        org = self.org_api.get_by_name(self.org)
+        if not org:
+            self.result['changed'] = False
+            self.result['msg'] = f"Org '{self.org}' not found."
+            return
+
+        # Naive match: look for description == name
+        for auth in self.client.find_authorizations(org_id=org.id):
+            if auth.description == self.name:
+                self.client.delete_authorization(auth.id)
+                self.result['changed'] = True
+                self.result['msg'] = f"Token '{self.name}' deleted"
+                return
+
+        self.result['changed'] = False
+        self.result['msg'] = f"No token named '{self.name}' found"
+        return
+
+    def handle_present(self):
+        org = self.org_api.get_by_name(self.org)
+        if not org or org.status != 'active':
+            self.result['failed'] = True
+            self.result['msg'] = f"Organization '{self.org}' not found or inactive"
+            return
+
+        influx_permissions = self._build_permissions(org_id=org.id)
+
+        existing_token = None
+        for token in self.client.find_authorizations(org_id=org.id):
+            if token.description == self.name:
+                existing_token = token
+                break
+
+        if existing_token:
+            if self._compare_permissions(existing_token.permissions, influx_permissions):
+                self.result['changed'] = False
+                self.result['msg'] = f"Token '{self.name}' already exists with same permissions"
+                self.result['token'] = existing_token.token
+                return
+            else:
+                self.client.delete_authorization(existing_token.id)
+                self.result['changed'] = True
+                self.result['msg'] = f"Token '{self.name}' permissions changed -> recreated"
+        else:
+            self.result['changed'] = True
+            self.result['msg'] = f"Token '{self.name}' created"
+
+        # Create token
+        auth_obj = Authorization(
+            org_id=org.id,
+            permissions=influx_permissions,
+            description=self.name
+        )
+        auth = self.client.create_authorization(authorization=auth_obj)
+        self.result['token'] = auth.token
+        return
+
+    def _compare_permissions(self, existing_perms, desired_perms):
+        """Compares two sets of permissions for actual equality."""
+        def serialize(perm):
+            return {
+                "action": perm.action,
+                "type": perm.resource.type,
+                "id": str(perm.resource.id),
+                "org_id": str(perm.resource.org_id)
+            }
+        
+        print("foo")
+
+        existing_set = sorted([serialize(p) for p in existing_perms], key=lambda x: (x["action"], x["type"], x["id"]))
+        desired_set = sorted([serialize(p) for p in desired_perms], key=lambda x: (x["action"], x["type"], x["id"]))
+
+        return existing_set == desired_set
+
+    def _build_permissions(self, org_id):
+        influx_permissions = []
+
+        for perm_block in self.permissions:
+            for resource_type, actions in perm_block.items():
+                if resource_type not in self.SUPPORTED_RESOURCES:
+                    raise Exception(f"Unsupported permission type: {resource_type}")
+
+                config = self.SUPPORTED_RESOURCES[resource_type]
+
+                for action_entry in actions:
+                    action = action_entry['action']
+                    resource_id = None
+
+                    # ggf. ID lookup für Ressourcen, die eine benannte Entität benötigen
+                    if config["resolver"] == "bucket":
+                        bucket_name = action_entry["bucket"]
+                        bucket = self.bucket_api.get_by_name(bucket_name)
+                        if not bucket:
+                            raise Exception(f"Bucket '{bucket_name}' not found")
+                        resource_id = bucket.id
+
+                    resource = PermissionResource(
+                        type=config["type"],
+                        id=resource_id,
+                        org_id=org_id
+                    )
+                    influx_permissions.append(Permission(action=action, resource=resource))
+
+        return influx_permissions

--- a/plugins/module_utils/influxdb2_bucket.py
+++ b/plugins/module_utils/influxdb2_bucket.py
@@ -116,3 +116,9 @@ class BucketApi():
 
     def get_by_id(self, id) -> Bucket:
         return self.client.find_bucket_by_id(id=id)
+
+    def get_by_name(self, name):
+        for bucket in self.get_all().buckets:
+            if bucket.name == name:
+                return self.get_by_id(bucket.id)
+        return None

--- a/plugins/modules/influxdb2_auth.py
+++ b/plugins/modules/influxdb2_auth.py
@@ -1,0 +1,172 @@
+# !/usr/bin/python3
+
+# Copyright (c) 2025, Tobias Bauriedel <tobias@bauriedel.de>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+from ansible.module_utils.basic import (
+    AnsibleModule
+)
+
+from ansible_collections.tbauriedel.influxdb2.plugins.module_utils.influxdb2_auth import (
+    AuthApi
+)
+
+DOCUMENTATION = r'''
+---
+module: influxdb2_auth
+short_description: Manage InfluxDB 2.x API tokens
+author: "Tobias Bauriedel (@tbauriedel)"
+description:
+  - Create or delete authorization tokens in InfluxDB 2.x.
+  - Token permissions are compared on update. If changed, the token is deleted and recreated.
+  - This will result in a changed token string.
+options:
+  name:
+    description:
+      - Logical name/description for the token (used as `description` field in InfluxDB).
+    required: true
+    type: str
+  org:
+    description:
+      - Name of the InfluxDB organization.
+    required: true
+    type: str
+  state:
+    description:
+      - Desired state of the token.
+    choices: [ present, absent ]
+    default: present
+    type: str
+  desc:
+    description:
+      - Optional description for the token.
+    required: false
+    type: str
+  host:
+    description:
+      - URL to the InfluxDB server (e.g. https://influxdb.example.com:8086).
+    required: true
+    type: str
+  token:
+    description:
+      - Token with administrative permissions to manage other tokens.
+    required: true
+    type: str
+    no_log: true
+  permissions:
+    description:
+      - List of resource permissions to assign to the token.
+      - Structure:
+        - A list of resources (e.g., C(buckets), C(dashboards), C(variables)) and their associated actions.
+      - For example:
+        - C({ buckets: [ { action: read, bucket: my-bucket } ] })
+        - C({ dashboards: [ { action: write } ] })
+    required: true
+    type: list
+  verify_ssl:
+    description:
+      - Whether to verify the InfluxDB SSL certificate.
+    required: false
+    type: bool
+    default: true
+notes:
+  - Changing permissions deletes and recreates the token.
+  - This means the token string will change.
+see also:
+  - name: InfluxDB Authorization API
+    description: InfluxDB API documentation for managing tokens
+'''
+
+EXAMPLES = r'''
+- name: Create an API token with bucket and dashboard access
+  tbauriedel.influxdb2.influxdb2_auth:
+    name: "my-token"
+    state: present
+    org: default
+    host: "https://influxdb.local:8086"
+    token: "{{ admin_token }}"
+    verify_ssl: false
+    permissions:
+      - buckets:
+          - action: read
+            bucket: my-bucket
+      - dashboards:
+          - action: read
+          - action: write
+
+- name: Delete a token
+  tbauriedel.influxdb2.influxdb2_auth:
+    name: "my-token"
+    state: absent
+    org: default
+    host: "https://influxdb.local:8086"
+    token: "{{ admin_token }}"
+'''
+
+RETURN = r'''
+token:
+  description: The token string created or matched.
+  type: str
+  returned: when state=present
+  sample: "my-generated-token-string=="
+changed:
+  description: Whether a change was made.
+  type: bool
+  returned: always
+msg:
+  description: Human-readable status message.
+  type: str
+  returned: always
+'''
+
+
+def run_module():
+    module = AnsibleModule(
+        argument_spec=dict(
+            name=dict(type=str, required=True),
+            org=dict(type=str, required=True),
+            state=dict(type=str, required=False),
+            desc=dict(type=str, required=False),
+            host=dict(type=str, required=True),
+            token=dict(type=str, required=True, no_log=True),
+            permissions=dict(type=list, required=True),
+            verify_ssl=dict(type=bool, required=False),
+        )
+    )
+
+    #module.debug("help")
+
+    result = dict(
+        changed=False,
+        failed=False,
+    )
+
+    if module.params['state'] != 'absent' and module.params['state'] != 'present':
+        result['stderr'] = "Invalid state given. Please use 'absent' or 'present'"
+        result['failed'] = True
+
+        module.exit_json(**result)
+
+    auth = AuthApi(
+        host=module.params['host'],
+        token=module.params['token'],
+        name=module.params['name'],
+        org=module.params['org'],
+        state=module.params['state'],
+        desc=module.params['desc'],
+        permissions=module.params['permissions'],
+        verify_ssl=module.params['verify_ssl']
+    )
+
+    auth.handle()
+
+    result = auth.return_result()
+
+    module.exit_json(**result)
+
+if __name__ == "__main__":
+    run_module()

--- a/plugins/modules/influxdb2_bucket.py
+++ b/plugins/modules/influxdb2_bucket.py
@@ -1,4 +1,12 @@
-#!/usr/bin/python3
+# !/usr/bin/python3
+
+# Copyright (c) 2024, Tobias Bauriedel <tobias@bauriedel.de>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
 # pylint: disable=missing-module-docstring
 
 from ansible.module_utils.basic import AnsibleModule

--- a/plugins/modules/influxdb2_organization.py
+++ b/plugins/modules/influxdb2_organization.py
@@ -1,5 +1,13 @@
-#!/usr/bin/python3
-# pylint: disable=missing-module-docstring
+# !/usr/bin/python3
+
+# Copyright (c) 2024, Tobias Bauriedel <tobias@bauriedel.de>
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+
+# # pylint: disable=missing-module-docstring
 
 from ansible.module_utils.basic import (
     AnsibleModule,

--- a/roles/influxdb2/README.md
+++ b/roles/influxdb2/README.md
@@ -39,6 +39,8 @@ At the moment the configuration is very basic. Over time, this role will be expa
   * `state`: State ('present' or 'absent')
   * `desc`: Description
   * `token`: API token to manage the organization
+  * `verify_ssl`: Verify ssl certificates (Default: `true`)
+  * `host`: InfluxDB Host to use in API call
 
 **Buckets**
 * `influxdb_influxdb2_buckets`: List of buckets to manage
@@ -47,10 +49,47 @@ At the moment the configuration is very basic. Over time, this role will be expa
   * `desc`: Description
   * `org`: InfluxDB organization name
   * `token`: API token to manage the bucket
+  * `verify_ssl`: Verify ssl certificates (Default: `true`)
+  * `host`: InfluxDB Host to use in API call
   * `retention`: Dict of retention rules containing a single object with the following fields
     * `type`: expire
     * `everySeconds`: Number of seconds to retain data (0 means forever)
     * `shardGroupDurationSeconds`: Number of seconds to retain shard groups (**Caution**: The [default values](https://docs.influxdata.com/influxdb/v2/reference/internals/shards/#shard-group-duration) also correspond to the necessary minimum!)
+
+**Access Tokens**
+* `influxdb2_influxdb2_tokens`:
+  * `name`: Name of token. Only used inside of the module to identify the token (saved in description)
+  * `state`: State of the token ('present' or 'absent')
+  * `desc`: Description (Only use in case you dont want to manage the token again after creation. Is used to identify it again)
+  * `org`: Organization name
+  * `token`: API token to manage the token
+  * `verify_ssl`: Verify ssl certificates (Default: `true`)
+  * `host`: InfluxDB Host to use in API call
+  * `permissions`: **List** of permissions. An example can be found below.
+
+```yaml
+permissions:
+  - buckets: # resource
+      - action: read # action
+        bucket: my-bucket # bucket name (only needed for the bucket resource)
+  - dashboards:
+      - action: read
+  - variables:
+      - action: read
+      - action: write
+  - ...
+```
+
+Supported resources:  
+- buckets (requires 'action' and 'bucket' name), dashboards, variables, tasks, checks, notifications, orgs, authorizations, labels, secrets, views, documents
+
+Supported actions:  
+- read, write
+
+> Note!
+> If an existing token’s permissions differ from the desired state, the module deletes and recreates the token under the hood.
+> This causes the actual token string to change. Plan accordingly if you store tokens externally or pass them to applications.
+
 
 Defaults can be viewed in vars/defaults.yml
 

--- a/roles/influxdb2/defaults/main.yml
+++ b/roles/influxdb2/defaults/main.yml
@@ -27,5 +27,6 @@ influxdb2_influxdb2_retention: 0
 
 influxdb2_influxdb2_buckets: []
 influxdb2_influxdb2_orgs: []
+influxdb2_influxdb2_tokens: []
 
 influxdb2_influxdb2_force_pip: false

--- a/roles/influxdb2/tasks/setup.yml
+++ b/roles/influxdb2/tasks/setup.yml
@@ -48,3 +48,15 @@
       everySeconds: "{{ item.retention.everySeconds }}"
       shardGroupDurationSeconds: "{{ item.retention.shardGroupDurationSeconds }}"
   loop: "{{ influxdb2_influxdb2_buckets }}"
+
+- name: Manage auth tokens
+  tbauriedel.influxdb2.influxdb2_auth:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    desc: "{{ item.desc | default(omit) }}"
+    org: "{{ item.org }}"
+    token: "{{ influxdb2_influxdb2_admin_token }}"
+    host: "{{ influxdb2_influxdb2_host }}"
+    verify_ssl: "{{ item.verify_ssl | default(true) }}"
+    permissions: "{{ item.permissions }}"
+  loop: "{{ influxdb2_influxdb2_tokens }}"


### PR DESCRIPTION
**Access Tokens**
* `tbauriedel.influxdb2.influxdb2_auth`:
  * `name`: Name of token. Only used inside of the module to identify the token (saved in description)
  * `state`: State of the token ('present' or 'absent')
  * `desc`: Description (Only use in case you dont want to manage the token again after creation. Is used to identify it again)
  * `org`: Organization name
  * `token`: API token to manage the token
  * `verify_ssl`: Verify ssl certificates (Default: `true`)
  * `host`: InfluxDB Host to use in API call
  * `permissions`: **List** of permissions. An example can be found below.

```yaml
permissions:
  - buckets: # resource
      - action: read # action
        bucket: my-bucket # bucket name (only needed for the bucket resource)
  - dashboards:
      - action: read
  - variables:
      - action: read
      - action: write
  - ...
```

Supported resources:  
- buckets (requires 'action' and 'bucket' name), dashboards, variables, tasks, checks, notifications, orgs, authorizations, labels, secrets, views, documents

Supported actions:  
- read, write

> Note!
> If an existing token’s permissions differ from the desired state, the module deletes and recreates the token under the hood.
> This causes the actual token string to change. Plan accordingly if you store tokens externally or pass them to applications.


fixes #17 